### PR TITLE
Add /opt/local/include to CPPPATH

### DIFF
--- a/wscript
+++ b/wscript
@@ -16,6 +16,7 @@ def configure(conf):
     if not conf.check(lib="sqlite3", libpath=['/usr/local/lib', '/opt/local/lib'], uselib_store="SQLITE3"):
       conf.fatal('Missing sqlite3');
   conf.env.append_value('LIBPATH_SQLITE3', '/opt/local/lib');
+  conf.env.append_value('CPPPATH_SQLITE3', '/opt/local/include');
 #   conf.check_cfg(package='profiler', args='--cflags --libs', uselib_store='SQLITE3')
 #   conf.env.append_value('LIBPATH_PROFILER', '/usr/local/lib')
 #   conf.env.append_value('LIB_PROFILER', 'profiler')


### PR DESCRIPTION
In the same way that /opt/local/lib is added to LIBPATH in wscript, it seems prudent to also add /opt/local/include to CPPPATH.

I use Mac OSX, with the default sqlite3 installation in /usr, and a newer version of sqlite3 in /opt/local.
Without this change, the build of node-sqlite finds libsqlite3.a in the /opt/local directory, but uses the sqlite3.h file from /usr/include, which is unfortunately out of date.  I've been using node-sqlite for a few months now, and keep modifying my local wscript with this change.  I'd prefer to use npm install over a manual git pull and build, but it won't work for me without this.  Not sure if others are running into this, too.

If you've got a better suggestion, I'm all ears, but it seems like either both CPPPATH and LIBPATH should be added, or neither of them.  Adding just one doesn't seem to cut it, at least not for me.
