### PR TITLE
Fixed package.json's JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
-{ 'name': 'sqlite'
-, 'description': 'SQLite3 bindings for Node'
-, 'version': '1.0.2'
-, 'homepage': 'http://github.com/orlandov/node-sqlite'
-, 'author':
-    'Orlando Vazquez <ovazquez@gmail.com> (http://2wycked.net)'
-, 'contributors':
-    [ 'Artem Kustikov'
-    , 'Eric Fredricksen'
-    , 'John Wright'
-    , 'Ryan Dahl'
+{ "name": "sqlite"
+, "description": "SQLite3 bindings for Node"
+, "version": "1.0.2"
+, "homepage": "http://github.com/orlandov/node-sqlite"
+, "author":
+    "Orlando Vazquez <ovazquez@gmail.com> (http://2wycked.net)"
+, "contributors":
+    [ "Artem Kustikov"
+    , "Eric Fredricksen"
+    , "John Wright"
+    , "Ryan Dahl"
     ]
-, 'repository':
-    { 'type': 'git'
-    , 'url': 'http://github.com/orlandov/node-sqlite.git'
+, "repository":
+    { "type": "git"
+    , "url": "http://github.com/orlandov/node-sqlite.git"
     }
-, 'main': 'sqlite'
-, 'engines': { 'node' : '>=0.2.0' }
-, 'scripts': { 'test' : './run-tests', preinstall: 'node-waf configure build' }
-, 'licenses':
-    [ { 'type' : 'BSD' } ]
-, 'main': './sqlite'
+, "main": "sqlite"
+, "engines": { "node" : ">=0.2.0" }
+, "scripts": { "test" : "./run-tests", "preinstall": "node-waf configure build" }
+, "licenses":
+    [ { "type" : "BSD" } ]
+, "main": "./sqlite"
 }


### PR DESCRIPTION
The current package.json was breaking NPM. I fixed it by replacing all single quotes with double ones and quoting "preinstall". This fixes this issue: https://github.com/orlandov/node-sqlite/issues#issue/24
